### PR TITLE
go 1.21.13

### DIFF
--- a/recipe/cgo/test.sh
+++ b/recipe/cgo/test.sh
@@ -22,6 +22,11 @@ case $(uname -s) in
   Darwin)
     if [[ $(uname -m) != arm64 ]]; then
         export CONDA_BUILD_SYSROOT=/opt/MacOSX10.14.sdk
+        # Use -k (keep going) because nocgo tests can "panic: test timed out after 10m0s" on osx-64
+        go tool dist test -k -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
+    else
+        # Expect PASS
+        go tool dist test -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
     fi
     # Expect PASS when run independently
     go tool dist test -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$' || true

--- a/recipe/compiler/build.sh
+++ b/recipe/compiler/build.sh
@@ -14,9 +14,6 @@ elif [[ "${target_platform}" == "linux-64" ]]; then
 elif [[ "${target_platform}" == "linux-aarch64" ]]; then
   export GOOS=linux
   export GOARCH=arm64
-elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
-  export GOOS=linux
-  export GOARCH=ppc64le
 fi
 
 sed -ie "s/\${GOOS}/${GOOS}/" "${RECIPE_DIR}/compiler/activate.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ source:
     # sha256: 49e394ab92bc6fa3df3d27298ddf3e4491f99477bee9dd4934525a526f3a391c  # [osx and arm64]
 
     url: https://go.dev/dl/go{{ version }}.darwin-amd64.tar.gz  # [osx]
-    sha256: 656ba058e137e36988bbf4ba06a313932f971e9cba268d50b6cfd66d029549a7  # [osx]
+    sha256: 796fd05e8741f6776c505eb201922864f2e32991679b639d9fcb524dbe300c0d  # [osx]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     sha256: 924655193634bfcdf7ec7a34589e0d73458741998a59e4155a929ce85f81af2d  # [win64]
 
     # url: https://go.dev/dl/go{{ version }}.darwin-arm64.tar.gz  # [osx and arm64]
-    # sha256: 49e394ab92bc6fa3df3d27298ddf3e4491f99477bee9dd4934525a526f3a391c  # [osx and arm64]
+    # sha256: c04ee7bdc0e65cf17133994c40ee9bdfa1b1dc9587b3baedaea39affdb8e5b49  # [osx and arm64]
 
     url: https://go.dev/dl/go{{ version }}.darwin-amd64.tar.gz  # [osx]
     sha256: 796fd05e8741f6776c505eb201922864f2e32991679b639d9fcb524dbe300c0d  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ source:
     # sha256: 49e394ab92bc6fa3df3d27298ddf3e4491f99477bee9dd4934525a526f3a391c  # [osx and arm64]
 
     url: https://go.dev/dl/go{{ version }}.darwin-amd64.tar.gz  # [osx]
-    sha256: 924655193634bfcdf7ec7a34589e0d73458741998a59e4155a929ce85f81af2d  # [osx]
+    sha256: 656ba058e137e36988bbf4ba06a313932f971e9cba268d50b6cfd66d029549a7  # [osx]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ source:
       - patches/0006-issue10607-is-only-valid-when-running-with-CGO.patch
       - patches/0007-Revert-cmd-link-enable-internal-linker-in-more-cases.patch
       - patches/0008-Mark-ftree-as-a-safe-compiler-flag.patch
+      # https://github.com/golang/go/issues/68088
+      - patches/0009-cmd-link-don-t-let-dsymutil-delete-our-temp-director.patch
   # Update this with a release from https://go.dev/dl/
   - folder: go-bootstrap  # [aarch64 or ppc64le or osx or win64 or (linux and x86_64)]
     url: https://go.dev/dl/go{{ version }}.linux-arm64.tar.gz  # [aarch64]
@@ -52,6 +54,9 @@ build:
     - $SYSROOT\System32\winmm.dll  # [win]
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch     # [unix]
   run:
     - {{ pin_subpackage(name, exact=true) }}
     - {{ compiler('c') }}  # [unix and cgo]
@@ -77,9 +82,6 @@ outputs:
       run:
         - _go_select =={{ go_variant_ver }}={{ go_variant_str }}
       run_constrained:
-        # TODO: Move to run section once conda/conda#9845 is fixed
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx]
-
         - {{ pin_compatible(compiler('c')) }}        # [unix and cgo]
         - {{ pin_compatible(compiler('cxx')) }}      # [unix and cgo]
         - {{ pin_compatible(compiler('fortran')) }}  # [unix and cgo]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "go" %}
-{% set version = "1.21.5" %}
+{% set version = "1.21.13" %}
 
 package:
   name: {{ name }}-{{ go_variant_str }}
@@ -8,7 +8,7 @@ package:
 source:
   - folder: go
     url: https://dl.google.com/{{ name }}/go{{ version }}.src.tar.gz
-    sha256: 285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19
+    sha256: 71fb31606a1de48d129d591e8717a63e0c5565ffba09a24ea9f899a13214c34d
     patches:
       # Please see patches/README.md for more details
       - patches/0001-Fix-cgo_fortran-test-setup-for-conda.patch
@@ -22,22 +22,19 @@ source:
   # Update this with a release from https://go.dev/dl/
   - folder: go-bootstrap  # [aarch64 or ppc64le or osx or win64 or (linux and x86_64)]
     url: https://go.dev/dl/go{{ version }}.linux-arm64.tar.gz  # [aarch64]
-    sha256: 841cced7ecda9b2014f139f5bab5ae31785f35399f236b8b3e75dff2a2978d96  # [aarch64]
+    sha256: 2ca2d70dc9c84feef959eb31f2a5aac33eefd8c97fe48f1548886d737bffabd4  # [aarch64]
 
     url: https://go.dev/dl/go{{ version }}.linux-amd64.tar.gz  # [linux and x86_64]
-    sha256: e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e  # [linux and x86_64]
-
-    url: https://go.dev/dl/go{{ version }}.linux-ppc64le.tar.gz  # [ppc64le]
-    sha256: 907b8c6ec4be9b184952e5d3493be66b1746442394a8bc78556c56834cd7c38b  # [ppc64le]
+    sha256: 502fc16d5910562461e6a6631fb6377de2322aad7304bf2bcd23500ba9dab4a7  # [linux and x86_64]
 
     url: https://go.dev/dl/go{{ version }}.windows-amd64.zip  # [win64]
-    sha256: bbe603cde7c9dee658f45164b4d06de1eff6e6e6b800100824e7c00d56a9a92f  # [win64]
+    sha256: 924655193634bfcdf7ec7a34589e0d73458741998a59e4155a929ce85f81af2d  # [win64]
 
     # url: https://go.dev/dl/go{{ version }}.darwin-arm64.tar.gz  # [osx and arm64]
     # sha256: 49e394ab92bc6fa3df3d27298ddf3e4491f99477bee9dd4934525a526f3a391c  # [osx and arm64]
 
     url: https://go.dev/dl/go{{ version }}.darwin-amd64.tar.gz  # [osx]
-    sha256: a2e1d5743e896e5fe1e7d96479c0a769254aed18cf216cf8f4c3a2300a9b3923  # [osx]
+    sha256: 924655193634bfcdf7ec7a34589e0d73458741998a59e4155a929ce85f81af2d  # [osx]
 
 build:
   number: 0

--- a/recipe/nocgo/test.sh
+++ b/recipe/nocgo/test.sh
@@ -20,7 +20,7 @@ go env
 case $(uname -s) in
   Darwin)
     if [[ $(uname -m) != arm64 ]]; then
-        # Use -k (keep going) because nocgo tests can "panic: test timed out after 10m0s"
+        # Use -k (keep going) because nocgo tests can "panic: test timed out after 10m0s" on osx-64
         go tool dist test -k -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
     else
         # Expect PASS

--- a/recipe/nocgo/test.sh
+++ b/recipe/nocgo/test.sh
@@ -19,8 +19,13 @@ go env
 # Run go's built-in test
 case $(uname -s) in
   Darwin)
-    # Expect PASS
-    go tool dist test -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
+    if [[ $(uname -m) != arm64 ]]; then
+        # Use -timeout 0 because nocgo tests can "panic: test timed out after 10m0s"
+        go tool dist test -timeout 0 -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
+    else
+        # Expect PASS
+        go tool dist test -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
+    fi
     # Occasionally FAILS
     go tool dist test -v -no-rebuild -run='^go_test:net/http$' || true
     go tool dist test -v -no-rebuild -run='^go_test:runtime$' || true

--- a/recipe/nocgo/test.sh
+++ b/recipe/nocgo/test.sh
@@ -20,8 +20,8 @@ go env
 case $(uname -s) in
   Darwin)
     if [[ $(uname -m) != arm64 ]]; then
-        # Use -timeout 0 because nocgo tests can "panic: test timed out after 10m0s"
-        go tool dist test -timeout 0 -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
+        # Use -k (keep going) because nocgo tests can "panic: test timed out after 10m0s"
+        go tool dist test -k -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'
     else
         # Expect PASS
         go tool dist test -v -no-rebuild -run='!^go_test:net/http|go_test:runtime|go_test:time$'

--- a/recipe/patches/0009-cmd-link-don-t-let-dsymutil-delete-our-temp-director.patch
+++ b/recipe/patches/0009-cmd-link-don-t-let-dsymutil-delete-our-temp-director.patch
@@ -1,0 +1,44 @@
+From f829204a9dc0fa8468a58cfca1758bdc5883dc3e Mon Sep 17 00:00:00 2001
+From: Cherry Mui <cherryyz@google.com>
+Date: Fri, 21 Jun 2024 11:56:45 -0400
+Subject: [PATCH 9/9] cmd/link: don't let dsymutil delete our temp directory
+
+To work around #59026, where dsymutil may not clean up its temp
+directory at exit, we set DSYMUTIL_REPRODUCER_PATH to our temp
+directory so it uses that, and we can delete it at the end.
+
+In Xcode 16 beta, dsymutil deletes the DSYMUTIL_REPRODUCER_PATH
+directory even if it is not empty. We still need our tmpdir at the
+point, so give a subdirectory to dsymutil instead.
+
+For #68088.
+
+Change-Id: I18759cc39512819bbd0511793ce917eae72245d6
+Reviewed-on: https://go-review.googlesource.com/c/go/+/593659
+Reviewed-by: Than McIntosh <thanm@google.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+---
+ src/cmd/link/internal/ld/lib.go | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 5e5d255..0755280 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1938,7 +1938,15 @@ func (ctxt *Link) hostlink() {
+ 		cmd := exec.Command(dsymutilCmd, "-f", *flagOutfile, "-o", dsym)
+ 		// dsymutil may not clean up its temp directory at exit.
+ 		// Set DSYMUTIL_REPRODUCER_PATH to work around. see issue 59026.
+-		cmd.Env = append(os.Environ(), "DSYMUTIL_REPRODUCER_PATH="+*flagTmpdir)
++		// dsymutil (Apple LLVM version 16.0.0) deletes the directory
++		// even if it is not empty. We still need our tmpdir, so give a
++		// subdirectory to dsymutil.
++		dsymDir := filepath.Join(*flagTmpdir, "dsymutil")
++		err = os.MkdirAll(dsymDir, 0777)
++		if err != nil {
++			Exitf("fail to create temp dir: %v", err)
++		}
++		cmd.Env = append(os.Environ(), "DSYMUTIL_REPRODUCER_PATH="+dsymDir)
+ 		if out, err := cmd.CombinedOutput(); err != nil {
+ 			Exitf("%s: running dsymutil failed: %v\n%s", os.Args[0], err, out)
+ 		}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5981](https://anaconda.atlassian.net/browse/PKG-5981) 
- [Upstream repository](https://github.com/golang/go/tree/go1.21.13)
- Home: https://go.dev/
- Changelog: https://go.dev/doc/devel/release#go1.21.minor

### Explanation of changes:

- Remove ppc64le source/url as we do not build for this platform


[PKG-5981]: https://anaconda.atlassian.net/browse/PKG-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ