### PR TITLE
v1.26.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "go" %}
-{% set version = "1.25.8" %}
+{% set version = "1.26.2" %}
 
 package:
   name: {{ name }}-{{ go_variant_str }}-split
@@ -8,7 +8,7 @@ package:
 source:
   - folder: go
     url: https://dl.google.com/{{ name }}/go{{ version }}.src.tar.gz
-    sha256: e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e
+    sha256: 2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b
     patches:
       # Please see patches/README.md for more details
       - patches/0001-Fix-cgo_fortran-test-setup-for-conda.patch
@@ -20,16 +20,16 @@ source:
   # Update this with a release from https://go.dev/dl/
   - folder: go-bootstrap
     url: https://go.dev/dl/go{{ version }}.linux-arm64.tar.gz  # [linux and aarch64]
-    sha256: 7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7  # [linux and aarch64]
+    sha256: c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23  # [linux and aarch64]
 
     url: https://go.dev/dl/go{{ version }}.linux-amd64.tar.gz  # [linux and x86_64]
-    sha256: ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6  # [linux and x86_64]
+    sha256: 990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282  # [linux and x86_64]
 
     url: https://go.dev/dl/go{{ version }}.windows-amd64.zip  # [win64]
-    sha256: 8d4ed9a270b33df7a6d3ff3a5316e103e0042fcc4f0c9a80e40378700bab6794  # [win64]
+    sha256: 98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708  # [win64]
     
     url: https://go.dev/dl/go{{ version }}.darwin-arm64.tar.gz  # [osx]
-    sha256: c6547959f5dbe8440bf3da972bd65ba900168de5e7ab01464fbdc7ac8375c21c  # [osx]
+    sha256: 32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af  # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
go v1.26.2

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-13508](https://anaconda.atlassian.net/browse/PKG-13508) 
- [Upstream repository](https://github.com/golang/go/tree/go1.26.2)
- [Upstream changelog/diff](https://github.com/golang/go/issues?q=milestone%3AGo1.26.2+label%3ACherryPickApproved)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/go-activation-feedstock/pull/3

### Explanation of changes:

- Bump version and SHAs


[PKG-13508]: https://anaconda.atlassian.net/browse/PKG-13508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ