### PR TITLE
Update version to 1.26.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "go" %}
-{% set version = "1.26.3" %}
+{% set version = "1.26.4" %}
 
 package:
   name: {{ name }}-{{ go_variant_str }}-split
@@ -8,7 +8,7 @@ package:
 source:
   - folder: go
     url: https://dl.google.com/{{ name }}/go{{ version }}.src.tar.gz
-    sha256: 1c646875d0aa8799133184ed57cf79ff24bdefe8c8820470602a9d3d6d9192b8
+    sha256: 4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d
     patches:
       # Please see patches/README.md for more details
       - patches/0001-Fix-cgo_fortran-test-setup-for-conda.patch
@@ -26,10 +26,10 @@ source:
     sha256: 2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556  # [linux and x86_64]
 
     url: https://go.dev/dl/go{{ version }}.windows-amd64.zip  # [win64]
-    sha256: 20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a  # [win64]
+    sha256: 3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345  # [win64]
 
     url: https://go.dev/dl/go{{ version }}.darwin-arm64.tar.gz  # [osx]
-    sha256: 875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c  # [osx]
+    sha256: b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53  # [osx]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,10 @@ source:
   # Update this with a release from https://go.dev/dl/
   - folder: go-bootstrap
     url: https://go.dev/dl/go{{ version }}.linux-arm64.tar.gz  # [linux and aarch64]
-    sha256: 9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565  # [linux and aarch64]
+    sha256: ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768  # [linux and aarch64]
 
     url: https://go.dev/dl/go{{ version }}.linux-amd64.tar.gz  # [linux and x86_64]
-    sha256: 2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556  # [linux and x86_64]
+    sha256: 1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f  # [linux and x86_64]
 
     url: https://go.dev/dl/go{{ version }}.windows-amd64.zip  # [win64]
     sha256: 3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345  # [win64]


### PR DESCRIPTION
go 1.26.4

**Destination channel:**  defaults

### Links

- [PKG-15124](https://anaconda.atlassian.net/browse/PKG-15124) 
- [Upstream repository](https://github.com/golang)

### Explanation of changes:
- New version number

[PKG-15124]: https://anaconda.atlassian.net/browse/PKG-15124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ